### PR TITLE
パンくずリストの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,4 +83,6 @@ gem 'sprockets-es6'
 
 group :production do
   gem 'unicorn', '5.4.1'
-end 
+end
+
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -353,6 +355,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -1,0 +1,20 @@
+.breadcrumbs-list{
+  background-color: #FFFFFF;
+  width: 1440px;
+  margin: 0 auto;
+  padding: 8px 0 0;
+  border-style: outset;
+  border-width: 1px;
+  box-shadow: 1px;
+  padding-left: 210px;
+  a{
+    color: black;
+  }
+  span{
+    font-weight:bold;
+  }
+  text{
+    font-weight:bold;
+  }
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import "cards";
 @import "trades";
 @import "logouts";
+@import "breadcrumbs";

--- a/app/views/logouts/index.html.haml
+++ b/app/views/logouts/index.html.haml
@@ -1,4 +1,6 @@
 = render partial: "./shared/item-header"
+-breadcrumb :logouts
+= render partial: "./shared/breadcrumbs"
 .main_container
   = render partial: "./mypages/side_menu" 
   .profile

--- a/app/views/mypages/edit.html.haml
+++ b/app/views/mypages/edit.html.haml
@@ -1,4 +1,6 @@
 = render partial: "./shared/item-header"
+-breadcrumb :profile
+= render partial: "./shared/breadcrumbs"
 .main_container
   = render partial: "profile"
   = render partial: "side_menu"

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,4 +1,6 @@
 = render partial: "./shared/item-header"
+-breadcrumb :mypages
+= render partial: "./shared/breadcrumbs"
 .mypage
   = render partial: "side_menu"
   .mypage__wrapper
@@ -7,4 +9,3 @@
     = render partial: "itemList"
 = render partial: "./items/appbanner"
 = render partial: "./shared/item-footer"
-

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/shipping_addresses/new.html.haml
+++ b/app/views/shipping_addresses/new.html.haml
@@ -1,5 +1,7 @@
 .rapper
   = render partial: "./shared/item-header"
+  -breadcrumb :shipping_addresses
+  = render partial: "./shared/breadcrumbs"
   .main
     = render partial: "./mypages/side_menu"
     .main__container.all-contents

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,6 +23,6 @@ crumb :profile do
 end
 
 # crumb : do
-#   link "商品名", show_items_path
+#   link "商品名", show_item_path
 #   parent :root
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -22,6 +22,11 @@ crumb :profile do
   parent :mypages
 end
 
+# crumb :profile do
+#   link "プロフィール", edit_mypage_path (current_user.id)
+#   parent :mypages
+# end
+
 # crumb : do
 #   link "商品名", show_item_path
 #   parent :root

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,6 +23,6 @@ crumb :profile do
 end
 
 # crumb : do
-#   link "商品名", _path
+#   link "商品名", show_items_path
 #   parent :root
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,6 +1,31 @@
 crumb :root do
-  link "Home", root_path
+  link "メルカリ", root_path
 end
+
+crumb :mypages do
+  link "マイページ", mypages_path
+  parent :root
+end
+
+crumb :logouts do
+  link "ログアウト", logouts_path
+  parent :mypages
+end
+
+crumb :shipping_addresses do
+  link "本人情報の登録", new_shipping_address_path
+  parent :mypages
+end
+
+crumb :profile do
+  link "プロフィール", edit_mypage_path
+  parent :mypages
+end
+
+# crumb : do
+#   link "商品名", _path
+#   parent :root
+# end
 
 # crumb :projects do
 #   link "Projects", projects_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -26,28 +26,3 @@ end
 #   link "商品名", _path
 #   parent :root
 # end
-
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
## WHAT
・メルカリと同等のパンくずリストを導入
・今回実装するページの中で、本家でパンくずが表示されている以下の項目について実装
メルカリ>マイページ
メルカリ>マイページ > ログアウト
メルカリ>マイページ > 本人情報の登録
メルカリ>マイページ > プロフィール
・本家で、各商品のページ下部に
メルカリ>『商品名』　とパンくずが表示されますが、ページを未実装の為、コメントアウトしています
## WHY
ユーザーが今WEBサイトのどの位置にいるのかを視覚化するため