### PR TITLE
[WIP]商品詳細表示サーバーサイド実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
     
   end
   def show
-  
+    @item =Item.find(params[:id])
   end
 
 end

--- a/app/views/items/_detail_title.html.haml
+++ b/app/views/items/_detail_title.html.haml
@@ -1,11 +1,3 @@
 %section.item-box
   %h1.item-box__title 
     = @item.name
-  %p.item-box__wording
-    『詩島様専用☆ディズニーシーバック』は、269回の取引実績を持つ
-    = link_to "https://18.176.249.67/", class: "item-box__wording-link" do
-      ししまる
-    さんから出品されました。
-    = link_to "https://18.176.249.67/", class: "item-box__wording-link" do 
-      キャラクターグッズ/おもちゃ・ホビー・グッズ
-    の商品で、未定から2~3日で発送されます。

--- a/app/views/items/_detail_title.html.haml
+++ b/app/views/items/_detail_title.html.haml
@@ -1,5 +1,6 @@
 %section.item-box
-  %h1.item-box__title 詩島様専用☆ディズニーシーバック
+  %h1.item-box__title 
+    = @item.name
   %p.item-box__wording
     『詩島様専用☆ディズニーシーバック』は、269回の取引実績を持つ
     = link_to "https://18.176.249.67/", class: "item-box__wording-link" do

--- a/app/views/shared/_elements.html.haml
+++ b/app/views/shared/_elements.html.haml
@@ -21,7 +21,7 @@
     %ul.items-elements
       - @item.each do |item|
         %li.items-element
-          = link_to image_tag(item.images[0].image ,class: 'items-element__image'),item_path(1)
+          = link_to image_tag(item.images[0].image ,class: 'items-element__image'),item_path(item)
           .items-element__name
             = item.name
           .items-element__price


### PR DESCRIPTION
# What
商品一覧画面から商品画像をクリックすると、その商品の詳細がメルカリ本家と同様に表示される
# Why
商品の詳細画面表示は、商品の購入等の機能を実装するために必須となるため