### PR TITLE
マイページ画面パンくず機能実装

### DIFF
--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -1,5 +1,5 @@
 = render partial: "./shared/item-header"
--breadcrumb :mypages
+-breadcrumb :address
 = render partial: "./shared/breadcrumbs"
 .mypage
   = render partial: "side_menu"

--- a/app/views/mypages/login_info.html.haml
+++ b/app/views/mypages/login_info.html.haml
@@ -1,5 +1,5 @@
 = render partial: "./shared/item-header"
--breadcrumb :profile
+-breadcrumb :login_info
 = render partial: "./shared/breadcrumbs"
 .main_container
   = render partial: "side_menu"

--- a/app/views/mypages/telephone.html.haml
+++ b/app/views/mypages/telephone.html.haml
@@ -1,5 +1,5 @@
 = render partial: "./shared/item-header"
--breadcrumb :mypages
+-breadcrumb :telephone
 = render partial: "./shared/breadcrumbs"
 .mypage
   = render partial: "side_menu"

--- a/app/views/payments/index.html.haml
+++ b/app/views/payments/index.html.haml
@@ -1,5 +1,5 @@
 = render partial: "./shared/item-header"
--breadcrumb :mypages
+-breadcrumb :payments
 = render partial: "./shared/breadcrumbs"
 .mypage
   = render partial: "./mypages/side_menu"

--- a/app/views/shipping_addresses/index.html.haml
+++ b/app/views/shipping_addresses/index.html.haml
@@ -1,5 +1,5 @@
 = render partial: "./shared/item-header"
--breadcrumb :mypages
+-breadcrumb :shipping_addresses
 = render partial: "./shared/breadcrumbs"
 .mypage
   = render partial: "./mypages/side_menu"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,19 +2,14 @@ crumb :root do
   link "メルカリ", root_path
 end
 
-crumb :mypages do
-  link "マイページ", mypages_path
-  parent :root
-end
-
-crumb :logouts do
-  link "ログアウト", logouts_path
-  parent :mypages
-end
-
 crumb :shipping_addresses do
   link "本人情報の登録", new_shipping_address_path
   parent :mypages
+end
+
+crumb :mypages do
+  link "マイページ", mypages_path
+  parent :root
 end
 
 crumb :profile do
@@ -32,6 +27,26 @@ crumb :payments do
   parent :mypages
 end
 
+crumb :login_info do
+  link "メール・パスワード", login_info_mypage_path
+  parent :mypages
+end
+
+crumb :address do
+  link "本人情報", address_mypage_path
+  parent :mypages
+end
+
+crumb :telephone do
+  link "電話番号の確認", telephone_mypage_path
+  parent :mypages
+end
+
+crumb :logouts do
+  link "ログアウト", logouts_path
+  parent :mypages
+end
+
 crumb :newcards do
   link "クレジットカード情報登録",new_card_path
   parent :cards
@@ -41,6 +56,8 @@ crumb :itemdeatail do
   link "#{Item.find(id = params[:id]).name}", item_path
   parent :root
 end
+
+
 
 # crumb :profile do
 #   link "プロフィール", edit_mypage_path (current_user.id)


### PR DESCRIPTION
# What
## UIに対する変更・画面
マイページ左下の「設定」からのリンクにはパンくずが上手く表示されていませんでしたが、
適正に表示されるように修正しました。
![](https://i.gyazo.com/add710c6f038c39e0d35f636056d08fa.png)

![](https://i.gyazo.com/36f85b3128bfd5fdde1034d8b301e9fe.png)

## 本プルリクエストによる影響範囲
特にありません
## 特にレビューをお願いしたい箇所
breadcrums.rb のパス設定が適正であるかどうかです

# Why
## UIに対する変更・画面
ユーザーのが利用するにあたり見た目を向上させる為です